### PR TITLE
카카오맵의 장소 상세페이지에서 장소 정보를 추출하는 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/intellij+all,eclipse,vs,macos,windows,java,gradle
 # Edit at https://www.toptal.com/developers/gitignore?templates=intellij+all,eclipse,vs,macos,windows,java,gradle
 
+### Custom ###
+chrome/chromedriver
+
 ### Eclipse ###
 .metadata
 bin/

--- a/src/main/java/com/zelusik/scraping/config/SeleniumConfig.java
+++ b/src/main/java/com/zelusik/scraping/config/SeleniumConfig.java
@@ -1,0 +1,22 @@
+package com.zelusik.scraping.config;
+
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SeleniumConfig {
+
+    @Bean
+    public ChromeOptions chromeOptions() {
+        ChromeOptions options = new ChromeOptions();
+        options.setPageLoadStrategy(PageLoadStrategy.NORMAL);
+        options.addArguments("--headless=chrome");
+        options.addArguments("--no-sandbox");
+        options.addArguments("--disable-gpu");
+        options.addArguments("--single-process");
+        options.addArguments("--disable-dev-shm-usage");
+        return options;
+    }
+}

--- a/src/main/java/com/zelusik/scraping/constant/Day.java
+++ b/src/main/java/com/zelusik/scraping/constant/Day.java
@@ -1,0 +1,47 @@
+package com.zelusik.scraping.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public enum Day {
+
+    MON("월"),
+    TUE("화"),
+    WED("수"),
+    THU("목"),
+    FRI("금"),
+    SAT("토"),
+    SUN("일");
+
+    private final String description;
+
+    public static Day valueOfDescription(char description) {
+        return valueOfDescription(String.valueOf(description));
+    }
+
+    public static Day valueOfDescription(String description) {
+        return Arrays.stream(values())
+                .filter(value -> value.getDescription().equals(description))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    public static List<Day> getValuesInRange(Day start, Day end) {
+        List<Day> result = new LinkedList<>();
+        boolean continueAdding = false;
+
+        for (Day day : values()) {
+            if (day == start) continueAdding = true;
+            if (continueAdding) result.add(day);
+            if (day == end) break;
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/zelusik/scraping/controller/PlaceScrapingController.java
+++ b/src/main/java/com/zelusik/scraping/controller/PlaceScrapingController.java
@@ -1,0 +1,56 @@
+package com.zelusik.scraping.controller;
+
+import com.zelusik.scraping.dto.place.BusinessHoursDto;
+import com.zelusik.scraping.dto.place.PlaceInfoResponse;
+import com.zelusik.scraping.service.PlaceScrapingService;
+import lombok.RequiredArgsConstructor;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@RequestMapping("/places/scrap")
+@RestController
+public class PlaceScrapingController {
+
+    private final PlaceScrapingService placeScrapingService;
+    private final ChromeOptions createOptions;
+
+    @GetMapping
+    public PlaceInfoResponse getKakaoPlaceInfo(@RequestParam String kakaoPid) {
+        ChromeDriver driver = new ChromeDriver(createOptions);
+        driver.get("https://place.map.kakao.com/" + kakaoPid);
+
+        // Dynamic page가 전부 loading 될 때까지 explicit wait. 최대 10초까지 기다린다.
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("mArticle")));
+
+        WebElement mArticle = driver.findElement(By.id("mArticle"));
+
+        BusinessHoursDto businessHours;
+        try {
+            businessHours = placeScrapingService.getBusinessHours(mArticle);
+        } catch (NoSuchElementException e) {
+            businessHours = new BusinessHoursDto(null, null);
+        }
+
+        String homepageUrl;
+        try {
+            homepageUrl = placeScrapingService.getHomepageUrl(mArticle);
+        } catch (NoSuchElementException e) {
+            homepageUrl = null;
+        }
+
+        return PlaceInfoResponse.of(businessHours, homepageUrl);
+    }
+}

--- a/src/main/java/com/zelusik/scraping/dto/place/BusinessHoursDto.java
+++ b/src/main/java/com/zelusik/scraping/dto/place/BusinessHoursDto.java
@@ -1,0 +1,14 @@
+package com.zelusik.scraping.dto.place;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class BusinessHoursDto {
+
+    private List<OpeningHourDto> openingHours;
+    private String closingHours;
+}

--- a/src/main/java/com/zelusik/scraping/dto/place/OpeningHourDto.java
+++ b/src/main/java/com/zelusik/scraping/dto/place/OpeningHourDto.java
@@ -1,0 +1,21 @@
+package com.zelusik.scraping.dto.place;
+
+import com.zelusik.scraping.constant.Day;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class OpeningHourDto {
+
+    private Day day;
+    private LocalTime openAt;
+    private LocalTime closeAt;
+
+    public static OpeningHourDto of(Day day, TimeDto time) {
+        return new OpeningHourDto(day, time.getOpenAt(), time.getCloseAt());
+    }
+}

--- a/src/main/java/com/zelusik/scraping/dto/place/PlaceInfoResponse.java
+++ b/src/main/java/com/zelusik/scraping/dto/place/PlaceInfoResponse.java
@@ -1,0 +1,20 @@
+package com.zelusik.scraping.dto.place;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class PlaceInfoResponse {
+
+    private List<OpeningHourDto> openingHours;
+    private String closingHours;
+    private String homepageUrl;
+
+    public static PlaceInfoResponse of(BusinessHoursDto businessHours, String homepageUrl) {
+        return new PlaceInfoResponse(businessHours.getOpeningHours(), businessHours.getClosingHours(), homepageUrl);
+    }
+}

--- a/src/main/java/com/zelusik/scraping/dto/place/TimeDto.java
+++ b/src/main/java/com/zelusik/scraping/dto/place/TimeDto.java
@@ -1,0 +1,19 @@
+package com.zelusik.scraping.dto.place;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class TimeDto {
+
+    LocalTime openAt;
+    LocalTime closeAt;
+
+    public static TimeDto of(LocalTime openAt, LocalTime closeAt) {
+        return new TimeDto(openAt, closeAt);
+    }
+}

--- a/src/main/java/com/zelusik/scraping/service/PlaceScrapingService.java
+++ b/src/main/java/com/zelusik/scraping/service/PlaceScrapingService.java
@@ -1,0 +1,85 @@
+package com.zelusik.scraping.service;
+
+import com.zelusik.scraping.constant.Day;
+import com.zelusik.scraping.dto.place.BusinessHoursDto;
+import com.zelusik.scraping.dto.place.OpeningHourDto;
+import com.zelusik.scraping.util.OpeningHoursConverter;
+import lombok.RequiredArgsConstructor;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class PlaceScrapingService {
+
+    private final OpeningHoursConverter converter;
+
+    public String getHomepageUrl(WebElement mArticle) throws NoSuchElementException {
+        return mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo > div.placeinfo_default.placeinfo_homepage a.link_homepage")).getAttribute("href");
+    }
+
+    public BusinessHoursDto getBusinessHours(WebElement mArticle) throws NoSuchElementException {
+        try {
+            WebElement expandBtn = mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo " +
+                    "div.location_detail.openhour_wrap > div.location_present a.btn_more"));
+            expandBtn.click();
+        } catch (NoSuchElementException e) {
+            WebElement ohInfo = mArticle.findElement(By.cssSelector("div.location_detail.openhour_wrap div.location_present"));
+
+            String title = ohInfo.findElement(By.cssSelector("strong.tit_operation > span")).getText();
+            if (!title.contains("영업")) {
+                return createBusinessHours(null, null);
+            }
+
+            String openingHours = ohInfo.findElement(By.cssSelector("ul.list_operation > li > span")).getText();
+            return createBusinessHours(openingHours, null);
+        }
+
+        WebElement operationList = mArticle.findElement(By.cssSelector("div.details_placeinfo div.fold_floor > div.inner_floor"));
+        String openingHours = operationList.findElement(By.cssSelector("ul:nth-child(2)")).getText();
+        return createBusinessHours(openingHours, getClosingHours(operationList));
+    }
+
+    private BusinessHoursDto createBusinessHours(String openingHours, String closingHours) {
+        List<OpeningHourDto> openingHourDtos = converter.parseStrToOHs(openingHours);
+        if (openingHours != null && closingHours == null) {
+            List<Day> ohDays = openingHourDtos.stream().map(OpeningHourDto::getDay).toList();
+            List<Day> missingDays = findMissingDays(ohDays);
+            closingHours = makeClosingHours(missingDays);
+        }
+        return new BusinessHoursDto(openingHourDtos, closingHours);
+    }
+
+    private List<Day> findMissingDays(List<Day> days) {
+        return Arrays.stream(Day.values()).filter(day -> !days.contains(day)).toList();
+    }
+
+    private String makeClosingHours(List<Day> missingDays) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < missingDays.size(); i++) {
+            sb.append(missingDays.get(i).getDescription()).append("요일");
+            if (i != missingDays.size() - 1) {
+                sb.append("\n");
+            }
+        }
+        return sb.length() > 0 ? sb.toString() : null;
+    }
+
+    private String getClosingHours(WebElement operationList) {
+        try {
+            if (operationList.findElement(By.cssSelector("strong:nth-child(3)")).getText().equals("휴무일")) {
+                return operationList.findElement(By.cssSelector("ul:nth-child(4)")).getText();
+            } else if (operationList.findElement(By.cssSelector("strong:nth-child(5)")).getText().equals("휴무일")) {
+                return operationList.findElement(By.cssSelector("ul:nth-child(6)")).getText();
+            }
+            return null;
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/zelusik/scraping/util/OpeningHoursConverter.java
+++ b/src/main/java/com/zelusik/scraping/util/OpeningHoursConverter.java
@@ -1,0 +1,87 @@
+package com.zelusik.scraping.util;
+
+import com.zelusik.scraping.constant.Day;
+import com.zelusik.scraping.dto.place.OpeningHourDto;
+import com.zelusik.scraping.dto.place.TimeDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Slf4j
+@Component
+public class OpeningHoursConverter {
+
+    public List<OpeningHourDto> parseStrToOHs(String openingHours) {
+        if (openingHours == null) return null;
+
+        List<OpeningHourDto> result = new ArrayList<>();
+        for (String oh : openingHours.split("\n")) {
+            oh = oh.trim();
+
+            if (oh.contains("라스트오더")) continue;
+            if (oh.contains("휴게시간")) continue;
+
+            if (oh.startsWith("매일")) {
+                // ex. 매일 11:30 ~ 22:00
+                TimeDto time = extractOpeningHoursTime(oh, 3);
+                result.addAll(mapOpeningHours(Arrays.stream(Day.values()), time));
+            } else if (oh.charAt(1) == '~') {
+                // ex. 월~토 18:00 ~ 02:00
+                Day startDay = Day.valueOfDescription(oh.charAt(0));
+                Day endDay = Day.valueOfDescription(oh.charAt(2));
+                List<Day> dayList = Day.getValuesInRange(startDay, endDay);
+                TimeDto time = extractOpeningHoursTime(oh, 4);
+                result.addAll(mapOpeningHours(dayList.stream(), time));
+            } else if (oh.charAt(1) == ',') {
+                // ex. 월,화,목,금,토,일 10:00 ~ 19:30
+                int firstSpaceIdx = oh.indexOf(" ");
+                List<Day> dayList = new ArrayList<>();
+                for (int i = 0; i < firstSpaceIdx; i += 2) {
+                    Day dayOfWeek = Day.valueOfDescription(oh.charAt(i));
+                    dayList.add(dayOfWeek);
+                }
+                TimeDto time = extractOpeningHoursTime(oh, firstSpaceIdx + 1);
+                result.addAll(mapOpeningHours(dayList.stream(), time));
+            } else if (oh.charAt(1) == ' ') {
+                // ex. 목 11:00 ~ 18:00
+                Day day = Day.valueOfDescription(oh.charAt(0));
+                TimeDto time = extractOpeningHoursTime(oh, 2);
+                result.add(OpeningHourDto.of(day, time));
+            } else {
+                log.error("장소 영업시간이 처리할 수 없는 형태입니다. text={}", oh);
+            }
+        }
+
+        // 요일 순서대로 정렬
+        Comparator<OpeningHourDto> ohComparator = Comparator.comparing(oh -> oh.getDay().ordinal());
+        return result.stream().sorted(ohComparator).toList();
+    }
+
+    /**
+     * 영업시간 정보(String)를 받아 영업 시작 시간과 영업 종료 시간을 추출한다.
+     *
+     * @param openingHours   영업시간 정보.
+     * @param openAtStartIdx 영업 시작 시간이 시작하는 index.
+     * @return openingHours에서 추출한 영업 시작 시간, 종료 시간 정보가 담긴 객체.Q
+     */
+    private TimeDto extractOpeningHoursTime(String openingHours, int openAtStartIdx) {
+        int closeAtStartIdx = openAtStartIdx + 5 + 3;
+
+        String subStrOpenAt = openingHours.substring(openAtStartIdx, openAtStartIdx + 5);
+        String subStrCloseAt = openingHours.substring(closeAtStartIdx, closeAtStartIdx + 5);
+        LocalTime openAt = subStrOpenAt.equals("24:00") ? LocalTime.of(23, 59) : LocalTime.parse(subStrOpenAt);
+        LocalTime closeAt = subStrCloseAt.equals("24:00") ? LocalTime.of(23, 59) : LocalTime.parse(subStrCloseAt);
+
+        return TimeDto.of(openAt, closeAt);
+    }
+
+    private static List<OpeningHourDto> mapOpeningHours(Stream<Day> dayList, TimeDto time) {
+        return dayList.map(day -> OpeningHourDto.of(day, time)).toList();
+    }
+}

--- a/src/test/java/com/zelusik/scraping/integration/controller/PlaceScrapingTest.java
+++ b/src/test/java/com/zelusik/scraping/integration/controller/PlaceScrapingTest.java
@@ -1,0 +1,136 @@
+package com.zelusik.scraping.integration.controller;
+
+import com.zelusik.scraping.controller.PlaceScrapingController;
+import com.zelusik.scraping.dto.place.OpeningHourDto;
+import com.zelusik.scraping.dto.place.PlaceInfoResponse;
+import com.zelusik.scraping.dto.place.TimeDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.zelusik.scraping.constant.Day.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("[Integration] Selenium을 활용해 장소 정보 가져오기")
+@SpringBootTest
+class PlaceScrapingTest {
+
+    @Autowired
+    private PlaceScrapingController sut;
+
+    @DisplayName("Kakao place id가 주어지면, 해당 장소의 영업시간, 휴무일, 홈페이지 주소를 가져오고 반환한다.")
+    @MethodSource("kakaoPlaceInfos")
+    @ParameterizedTest(name = "[{index}] kakaoPid={0}")
+    void getKakaoPlaceInfoTest(String kakaoPid, List<OpeningHourDto> openingHours, String closingHours, String homepage) {
+        // given
+
+        // when
+        PlaceInfoResponse actualResult = sut.getKakaoPlaceInfo(kakaoPid);
+
+        // then
+        if (openingHours != null) {
+            assertThat(actualResult.getOpeningHours().size()).isEqualTo(openingHours.size());
+            for (int i = 0; i < openingHours.size(); i++) {
+                assertThat(actualResult.getOpeningHours().get(i).getDay()).isEqualTo(openingHours.get(i).getDay());
+                assertThat(actualResult.getOpeningHours().get(i).getOpenAt()).isEqualTo(openingHours.get(i).getOpenAt());
+                assertThat(actualResult.getOpeningHours().get(i).getCloseAt()).isEqualTo(openingHours.get(i).getCloseAt());
+            }
+        } else {
+            assertThat(actualResult.getOpeningHours()).isNullOrEmpty();
+        }
+        assertThat(actualResult.getClosingHours()).isEqualTo(closingHours);
+        assertThat(actualResult.getHomepageUrl()).isEqualTo(homepage);
+    }
+
+    static Stream<Arguments> kakaoPlaceInfos() {
+        return Stream.of(
+                arguments("682903436", null, null, null),
+                arguments("14575281",
+                        List.of(OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30)))),
+                        "월요일", null),
+                arguments("308342289",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0)))),
+                        null, "https://www.instagram.com/toma_wv/"),
+                arguments("25001083",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59)))),
+                        null, "http://www.mcdonalds.co.kr/"),
+                arguments("24529744",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0)))),
+                        null, "https://m.booking.naver.com/booking/6/bizes/137321/items/2713823?area=ple"),
+                arguments("13318338",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(22, 0)))),
+                        null, "http://cestlavie.fordining.kr/"),
+                arguments("20995567",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30)))),
+                        null, "https://dunsanmasil.modoo.at/"),
+                arguments("184145085",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(18, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0)))),
+                        "금요일", "https://www.instagram.com/hi_hasand"),
+                arguments("8149130",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0)))),
+                        "설당일\n설전날\n설다음날\n추석당일\n추석전날\n추석다음날", "http://www.xn--w39a45ki5j7idj7fkmcgy7b.com/"),
+                arguments("1399098939",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30)))),
+                        "수요일", null)
+        );
+    }
+}

--- a/src/test/java/com/zelusik/scraping/unit/service/PlaceScrapingServiceTest.java
+++ b/src/test/java/com/zelusik/scraping/unit/service/PlaceScrapingServiceTest.java
@@ -1,0 +1,249 @@
+package com.zelusik.scraping.unit.service;
+
+import com.zelusik.scraping.dto.place.BusinessHoursDto;
+import com.zelusik.scraping.dto.place.OpeningHourDto;
+import com.zelusik.scraping.dto.place.TimeDto;
+import com.zelusik.scraping.service.PlaceScrapingService;
+import com.zelusik.scraping.util.OpeningHoursConverter;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static com.zelusik.scraping.constant.Day.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("[Unit] Place scraping service test")
+@ExtendWith(MockitoExtension.class)
+class PlaceScrapingServiceTest {
+
+    @InjectMocks
+    private PlaceScrapingService sut;
+
+    @Mock
+    private OpeningHoursConverter converter;
+
+    @DisplayName("mArticle에서 homepage url을 추출하면, 추출된 homepage url이 반환된다.")
+    @Test
+    void givenMArticle_whenGetHomepageUrl_thenReturnHomepageUrl() {
+        // given
+        WebElement mArticle = createWebElemMock("mArticle");
+        WebElement homepage = createWebElemMock("homepage");
+        String expectedResult = "Hello";
+        given(mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo > div.placeinfo_default.placeinfo_homepage a.link_homepage"))).willReturn(homepage);
+        given(homepage.getAttribute("href")).willReturn(expectedResult);
+
+        // when
+        String actualResult = sut.getHomepageUrl(mArticle);
+
+        // then
+        assertThat(actualResult).isEqualTo(expectedResult);
+    }
+
+    @DisplayName("Homepage url 정보가 없는 mArticle에서 homepage url을 추출하면, 예외가 발생한다.")
+    @Test
+    void givenMArticleWithoutHomepageUrl_whenGetHomepageUrl_thenReturnHomepageUrl() {
+        // given
+        WebElement mArticle = createWebElemMock("mArticle");
+        given(mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo > div.placeinfo_default.placeinfo_homepage a.link_homepage"))).willThrow(NoSuchElementException.class);
+
+        // when
+        Throwable t = catchThrowable(() -> sut.getHomepageUrl(mArticle));
+
+        // then
+        assertThat(t).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @DisplayName("영업시간 조회 - 버튼을 눌러 정보 열람 후, 영업시간과 휴무일 모두 있는 경우")
+    @Test
+    void existsButtonAndOpeningAndClosingHours_whenGetBusinessHours_thenReturnResult() {
+        // given
+        WebElement mArticle = createWebElemMock("mArticle");
+        WebElement button = createWebElemMock("button");
+        WebElement operationList = createWebElemMock("operationList");
+        String openingHours = "수~일 10:30 ~ 15:30";
+        List<OpeningHourDto> openingHourDtos = createOpeningHourDtoList();
+        String closingHours = "월요일\n화요일";
+        BusinessHoursDto expectedResult = new BusinessHoursDto(openingHourDtos, closingHours);
+
+        given(mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo " +
+                "div.location_detail.openhour_wrap > div.location_present a.btn_more"))).willReturn(button);
+        willDoNothing().given(button).click();
+        given(mArticle.findElement(By.cssSelector("div.details_placeinfo div.fold_floor > div.inner_floor"))).willReturn(operationList);
+        WebElement openingHoursElem = createWebElemMock("openingHours");
+        given(operationList.findElement(By.cssSelector("ul:nth-child(2)"))).willReturn(openingHoursElem);
+        given(openingHoursElem.getText()).willReturn(openingHours);
+        WebElement closingHoursTitleElem = createWebElemMock("closingHoursTitle");
+        given(operationList.findElement(By.cssSelector("strong:nth-child(3)"))).willReturn(closingHoursTitleElem);
+        given(closingHoursTitleElem.getText()).willReturn("휴무일");
+        WebElement closingHoursElem = createWebElemMock("closingHours");
+        given(operationList.findElement(By.cssSelector("ul:nth-child(4)"))).willReturn(closingHoursElem);
+        given(closingHoursElem.getText()).willReturn(closingHours);
+        given(converter.parseStrToOHs(openingHours)).willReturn(openingHourDtos);
+
+        // when
+        BusinessHoursDto actualResult = sut.getBusinessHours(mArticle);
+
+        // then
+        verifyGetBusinessHours(openingHours, expectedResult, actualResult);
+    }
+
+    @DisplayName("영업시간 조회 - 버튼을 눌러 정보 열람 후, 영업시간과 휴무일 모두 있으나 휴무일 이전에 다른 정보(공휴일 등)가 함께 있는 경우")
+    @Test
+    void existsButtonAndOpeningAndClosingHoursAndAdditionalInfo_whenGetBusinessHours_thenReturnResult() {
+        // given
+        WebElement mArticle = createWebElemMock("mArticle");
+        WebElement button = createWebElemMock("button");
+        WebElement operationList = createWebElemMock("operationList");
+        String openingHours = "수~일 10:30 ~ 15:30";
+        List<OpeningHourDto> openingHourDtos = createOpeningHourDtoList();
+        String closingHours = "월요일\n화요일";
+        BusinessHoursDto expectedResult = new BusinessHoursDto(openingHourDtos, closingHours);
+
+        given(mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo " +
+                "div.location_detail.openhour_wrap > div.location_present a.btn_more"))).willReturn(button);
+        willDoNothing().given(button).click();
+        given(mArticle.findElement(By.cssSelector("div.details_placeinfo div.fold_floor > div.inner_floor"))).willReturn(operationList);
+        WebElement openingHoursElem = createWebElemMock("openingHours");
+        given(operationList.findElement(By.cssSelector("ul:nth-child(2)"))).willReturn(openingHoursElem);
+        given(openingHoursElem.getText()).willReturn(openingHours);
+        WebElement closingHoursTitleElem1 = createWebElemMock("closingHoursTitle1");
+        given(operationList.findElement(By.cssSelector("strong:nth-child(3)"))).willReturn(closingHoursTitleElem1);
+        given(closingHoursTitleElem1.getText()).willReturn("공휴일");
+        WebElement closingHoursTitleElem2 = createWebElemMock("closingHoursTitle2");
+        given(operationList.findElement(By.cssSelector("strong:nth-child(5)"))).willReturn(closingHoursTitleElem2);
+        given(closingHoursTitleElem2.getText()).willReturn("휴무일");
+        WebElement closingHoursElem = createWebElemMock("closingHours");
+        given(operationList.findElement(By.cssSelector("ul:nth-child(6)"))).willReturn(closingHoursElem);
+        given(closingHoursElem.getText()).willReturn(closingHours);
+        given(converter.parseStrToOHs(openingHours)).willReturn(openingHourDtos);
+
+        // when
+        BusinessHoursDto actualResult = sut.getBusinessHours(mArticle);
+
+        // then
+        verifyGetBusinessHours(openingHours, expectedResult, actualResult);
+    }
+
+    @DisplayName("영업시간 조회 - 버튼을 눌러 정보 열람 후, 휴무일이 없는 경우")
+    @Test
+    void existsButtonAndOpeningHours_whenGetBusinessHours_thenReturnResult() {
+        // given
+        WebElement mArticle = createWebElemMock("mArticle");
+        WebElement button = createWebElemMock("button");
+        WebElement operationList = createWebElemMock("operationList");
+        String openingHours = "수~일 10:30 ~ 15:30";
+        List<OpeningHourDto> openingHourDtos = createOpeningHourDtoList();
+        String closingHours = "월요일\n화요일";
+        BusinessHoursDto expectedResult = new BusinessHoursDto(openingHourDtos, closingHours);
+
+        given(mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo " +
+                "div.location_detail.openhour_wrap > div.location_present a.btn_more"))).willReturn(button);
+        willDoNothing().given(button).click();
+        given(mArticle.findElement(By.cssSelector("div.details_placeinfo div.fold_floor > div.inner_floor"))).willReturn(operationList);
+        WebElement openingHoursElem = createWebElemMock("openingHours");
+        given(operationList.findElement(By.cssSelector("ul:nth-child(2)"))).willReturn(openingHoursElem);
+        given(openingHoursElem.getText()).willReturn(openingHours);
+        given(operationList.findElement(By.cssSelector("strong:nth-child(3)"))).willThrow(NoSuchElementException.class);
+        given(converter.parseStrToOHs(openingHours)).willReturn(openingHourDtos);
+
+        // when
+        BusinessHoursDto actualResult = sut.getBusinessHours(mArticle);
+
+        // then
+        verifyGetBusinessHours(openingHours, expectedResult, actualResult);
+    }
+
+    @DisplayName("영업시간 조회 - 버튼이 없고, 영업시간은 있는 경우")
+    @Test
+    void existsOpeningHours_whenGetBusinessHours_thenReturnResult() {
+        // given
+        WebElement mArticle = createWebElemMock("mArticle");
+        WebElement ohInfo = createWebElemMock("ohInfo");
+        String openingHours = "수~일 10:30 ~ 15:30";
+        List<OpeningHourDto> openingHourDtos = createOpeningHourDtoList();
+        String closingHours = "월요일\n화요일";
+        BusinessHoursDto expectedResult = new BusinessHoursDto(openingHourDtos, closingHours);
+
+        given(mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo " +
+                "div.location_detail.openhour_wrap > div.location_present a.btn_more"))).willThrow(NoSuchElementException.class);
+        given(mArticle.findElement(By.cssSelector("div.location_detail.openhour_wrap div.location_present"))).willReturn(ohInfo);
+        WebElement ohInfoTitleElem = createWebElemMock("ohInfoTitle");
+        given(ohInfo.findElement(By.cssSelector("strong.tit_operation > span"))).willReturn(ohInfoTitleElem);
+        given(ohInfoTitleElem.getText()).willReturn("영업시간");
+        WebElement openingHoursElem = createWebElemMock("openingHours");
+        given(ohInfo.findElement(By.cssSelector("ul.list_operation > li > span"))).willReturn(openingHoursElem);
+        given(openingHoursElem.getText()).willReturn(openingHours);
+        given(converter.parseStrToOHs(openingHours)).willReturn(openingHourDtos);
+
+        // when
+        BusinessHoursDto actualResult = sut.getBusinessHours(mArticle);
+
+        // then
+        verifyGetBusinessHours(openingHours, expectedResult, actualResult);
+    }
+
+    @DisplayName("영업시간 조회 - 버튼이 없고, 영업시간 정보도 없는 경우(title이 영업시간이 아닌 경우)")
+    @Test
+    void existsNothing_whenGetBusinessHours_thenReturnResult() {
+        // given
+        WebElement mArticle = createWebElemMock("mArticle");
+        WebElement ohInfo = createWebElemMock("ohInfo");
+        BusinessHoursDto expectedResult = new BusinessHoursDto(null, null);
+        given(mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo " +
+                "div.location_detail.openhour_wrap > div.location_present a.btn_more"))).willThrow(NoSuchElementException.class);
+        given(mArticle.findElement(By.cssSelector("div.location_detail.openhour_wrap div.location_present"))).willReturn(ohInfo);
+        WebElement ohInfoTitleElem = createWebElemMock("ohInfoTitle");
+        given(ohInfo.findElement(By.cssSelector("strong.tit_operation > span"))).willReturn(ohInfoTitleElem);
+        given(ohInfoTitleElem.getText()).willReturn("정보");
+
+        // when
+        BusinessHoursDto actualResult = sut.getBusinessHours(mArticle);
+
+        // then
+        verifyGetBusinessHours(null, expectedResult, actualResult);
+    }
+
+    @NotNull
+    private static List<OpeningHourDto> createOpeningHourDtoList() {
+        return List.of(
+                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30)))
+        );
+    }
+
+    private WebElement createWebElemMock(String name) {
+        return Mockito.mock(WebElement.class, name);
+    }
+
+    private void verifyGetBusinessHours(String openingHours, BusinessHoursDto expectedResult, BusinessHoursDto actualResult) {
+        then(converter).should().parseStrToOHs(openingHours);
+        then(converter).shouldHaveNoMoreInteractions();
+        if (expectedResult.getOpeningHours() != null) {
+            assertThat(actualResult.getOpeningHours().size()).isEqualTo(expectedResult.getOpeningHours().size());
+            for (int i = 0; i < expectedResult.getOpeningHours().size(); i++) {
+                assertThat(actualResult.getOpeningHours().get(i).getDay()).isEqualTo(expectedResult.getOpeningHours().get(i).getDay());
+                assertThat(actualResult.getOpeningHours().get(i).getOpenAt()).isEqualTo(expectedResult.getOpeningHours().get(i).getOpenAt());
+                assertThat(actualResult.getOpeningHours().get(i).getCloseAt()).isEqualTo(expectedResult.getOpeningHours().get(i).getCloseAt());
+            }
+        } else {
+            assertThat(actualResult.getOpeningHours()).isNullOrEmpty();
+        }
+        assertThat(actualResult.getClosingHours()).isEqualTo(expectedResult.getClosingHours());
+    }
+}

--- a/src/test/java/com/zelusik/scraping/unit/util/OpeningHoursConverterTest.java
+++ b/src/test/java/com/zelusik/scraping/unit/util/OpeningHoursConverterTest.java
@@ -1,0 +1,129 @@
+package com.zelusik.scraping.unit.util;
+
+import com.zelusik.scraping.dto.place.OpeningHourDto;
+import com.zelusik.scraping.dto.place.TimeDto;
+import com.zelusik.scraping.util.OpeningHoursConverter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.zelusik.scraping.constant.Day.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("[Unit] 영업시간 converter test")
+class OpeningHoursConverterTest {
+
+    private final OpeningHoursConverter sut;
+
+    public OpeningHoursConverterTest() {
+        this.sut = new OpeningHoursConverter();
+    }
+
+    @DisplayName("문자열 형태의 영업시간이 주어지면, 영업시간을 List<OpeningHourDto> 형태로 변환한다.")
+    @MethodSource("openingHoursTestData")
+    @ParameterizedTest(name = "[{index}] openingHours={0}")
+    void parseStringToOpeningHours(String openingHours, List<OpeningHourDto> expectedResult) {
+        // given
+
+        // when
+        List<OpeningHourDto> actualResult = sut.parseStrToOHs(openingHours);
+
+        // then
+        assertThat(actualResult.size()).isEqualTo(expectedResult.size());
+        for (int i = 0; i < actualResult.size(); i++) {
+            assertThat(actualResult.get(i).getDay()).isEqualTo(expectedResult.get(i).getDay());
+            assertThat(actualResult.get(i).getOpenAt()).isEqualTo(expectedResult.get(i).getOpenAt());
+            assertThat(actualResult.get(i).getCloseAt()).isEqualTo(expectedResult.get(i).getCloseAt());
+        }
+    }
+
+    static Stream<Arguments> openingHoursTestData() {
+        return Stream.of(
+                arguments(
+                        "화~일 10:30 ~ 15:30",
+                        List.of(OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))))
+                ),
+                arguments(
+                        "매일 07:30 ~ 24:00",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))))
+                ),
+                arguments(
+                        "월~토 11:00 ~ 01:00\n일 11:00 ~ 22:00",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(1, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(22, 0))))
+                ),
+                arguments(
+                        "월,화,수,토,일 11:00 ~ 19:00\n목 11:00 ~ 18:00",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(18, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 0), LocalTime.of(19, 0))))
+                ),
+                arguments(
+                        "매일 11:30 ~ 22:00\n매일 라스트오더 ~ 21:00",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))))
+                ),
+                arguments(
+                        "매일 11:30 ~ 21:30\n매일 휴게시간 15:00 ~ 17:00",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(21, 30))))
+                ),
+                arguments(
+                        "매일 11:30 ~ 22:00\n월~금 휴게시간 15:00 ~ 17:00\n토,일 휴게시간 15:30 ~ 17:00",
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))))
+                ),
+                arguments(
+                        "월,화,목,금,토,일 10:00 ~ 19:30\n월,화,목,금,토,일 휴게시간 15:10 ~ 17:00",
+
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(10, 0), LocalTime.of(19, 30))))
+
+                )
+        );
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #3

## 🏃‍ Task
- 카카오맵의 장소 상세페이지에서 장소 정보를 추출하는 기능 구현

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가?
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
