### PR TITLE
카카오맵 장소 상세페이지 html 문서 변경에 따른 수정사항 반영

### DIFF
--- a/src/main/java/com/zelusik/scraping/service/PlaceScrapingService.java
+++ b/src/main/java/com/zelusik/scraping/service/PlaceScrapingService.java
@@ -31,12 +31,12 @@ public class PlaceScrapingService {
         } catch (NoSuchElementException e) {
             WebElement ohInfo = mArticle.findElement(By.cssSelector("div.location_detail.openhour_wrap div.location_present"));
 
-            String title = ohInfo.findElement(By.cssSelector("strong.tit_operation > span")).getText();
+            String title = ohInfo.findElement(By.cssSelector("strong.tit_operation")).getText();
             if (!title.contains("영업")) {
                 return createBusinessHours(null, null);
             }
 
-            String openingHours = ohInfo.findElement(By.cssSelector("ul.list_operation > li > span")).getText();
+            String openingHours = ohInfo.findElement(By.cssSelector("ul.list_operation")).getText();
             return createBusinessHours(openingHours, null);
         }
 

--- a/src/test/java/com/zelusik/scraping/unit/service/PlaceScrapingServiceTest.java
+++ b/src/test/java/com/zelusik/scraping/unit/service/PlaceScrapingServiceTest.java
@@ -181,10 +181,10 @@ class PlaceScrapingServiceTest {
                 "div.location_detail.openhour_wrap > div.location_present a.btn_more"))).willThrow(NoSuchElementException.class);
         given(mArticle.findElement(By.cssSelector("div.location_detail.openhour_wrap div.location_present"))).willReturn(ohInfo);
         WebElement ohInfoTitleElem = createWebElemMock("ohInfoTitle");
-        given(ohInfo.findElement(By.cssSelector("strong.tit_operation > span"))).willReturn(ohInfoTitleElem);
+        given(ohInfo.findElement(By.cssSelector("strong.tit_operation"))).willReturn(ohInfoTitleElem);
         given(ohInfoTitleElem.getText()).willReturn("영업시간");
         WebElement openingHoursElem = createWebElemMock("openingHours");
-        given(ohInfo.findElement(By.cssSelector("ul.list_operation > li > span"))).willReturn(openingHoursElem);
+        given(ohInfo.findElement(By.cssSelector("ul.list_operation"))).willReturn(openingHoursElem);
         given(openingHoursElem.getText()).willReturn(openingHours);
         given(converter.parseStrToOHs(openingHours)).willReturn(openingHourDtos);
 
@@ -206,7 +206,7 @@ class PlaceScrapingServiceTest {
                 "div.location_detail.openhour_wrap > div.location_present a.btn_more"))).willThrow(NoSuchElementException.class);
         given(mArticle.findElement(By.cssSelector("div.location_detail.openhour_wrap div.location_present"))).willReturn(ohInfo);
         WebElement ohInfoTitleElem = createWebElemMock("ohInfoTitle");
-        given(ohInfo.findElement(By.cssSelector("strong.tit_operation > span"))).willReturn(ohInfoTitleElem);
+        given(ohInfo.findElement(By.cssSelector("strong.tit_operation"))).willReturn(ohInfoTitleElem);
         given(ohInfoTitleElem.getText()).willReturn("정보");
 
         // when


### PR DESCRIPTION
## 🔥 Related Issue
- Close #이슈번호

## 🏃‍ Task
- 영업시간의 title을 조회하는 부분의 css selector를 `strong.tit_operation > span`에서 `strong.tit-operation`으로 변경하여 `<span>` tag가 있는 경우와 없는 경우 모두 text를 조회할 수 있도록 변경하였음.
- 마찬가지로 영업시간의 text를 읽어오는 부분의 css seletor도 `ul.list_operation > li > span`에서 `ul.list_operation`으로 변경함으로써 더 다양한 경우를 커버할 수 있도록 하였음.

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가?
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
