### PR TITLE
refactor: #12 변경된 웹페이지(23.7.17)를 기준으로 영업시간과 휴무일을 정상적으로 추출할 수 있도록 리팩토링

### DIFF
--- a/src/main/java/com/zelusik/scraping/service/KakaoPlaceScrapingService.java
+++ b/src/main/java/com/zelusik/scraping/service/KakaoPlaceScrapingService.java
@@ -40,9 +40,12 @@ public class KakaoPlaceScrapingService {
             return createBusinessHours(openingHours, null);
         }
 
+        // TODO: div.inner_floor, div.displayPeriodList ul이 반드시 존재한다고 가정한 코드. 아닌 경우가 있다면 try-catch로 감싸야한다.
         WebElement operationList = mArticle.findElement(By.cssSelector("div.details_placeinfo div.fold_floor > div.inner_floor"));
-        String openingHours = operationList.findElement(By.cssSelector("ul:nth-child(2)")).getText();
-        return createBusinessHours(openingHours, getClosingHours(operationList));
+        String openingHours = operationList.findElement(By.cssSelector("div.displayPeriodList > ul:nth-child(2)")).getText();
+        System.out.println(openingHours);
+        String closingHours = getClosingHours(operationList);
+        return createBusinessHours(openingHours, closingHours);
     }
 
     private BusinessHoursDto createBusinessHours(String openingHours, String closingHours) {
@@ -72,12 +75,7 @@ public class KakaoPlaceScrapingService {
 
     private String getClosingHours(WebElement operationList) {
         try {
-            if (operationList.findElement(By.cssSelector("strong:nth-child(3)")).getText().equals("휴무일")) {
-                return operationList.findElement(By.cssSelector("ul:nth-child(4)")).getText();
-            } else if (operationList.findElement(By.cssSelector("strong:nth-child(5)")).getText().equals("휴무일")) {
-                return operationList.findElement(By.cssSelector("ul:nth-child(6)")).getText();
-            }
-            return null;
+            return operationList.findElement(By.cssSelector("div.displayOffdayList > ul:nth-child(2)")).getText();
         } catch (NoSuchElementException e) {
             return null;
         }

--- a/src/test/java/com/zelusik/scraping/integration/controller/KakaoPlaceScrapingTest.java
+++ b/src/test/java/com/zelusik/scraping/integration/controller/KakaoPlaceScrapingTest.java
@@ -4,6 +4,7 @@ import com.zelusik.scraping.controller.KakaoPlaceScrapingController;
 import com.zelusik.scraping.dto.place.OpeningHourDto;
 import com.zelusik.scraping.dto.place.PlaceInfoResponse;
 import com.zelusik.scraping.dto.place.TimeDto;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -20,8 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @DisplayName("[Integration] Selenium을 활용해 장소 정보 가져오기")
+@Disabled("실제 가게 정보는 수시로 바뀔 수 있으므로 기능의 정상적인 동작을 확인하기에 불안정하다. 따라서 평소에는 disabled 해놓고 필요할 때 테스트하는 방식으로 사용한다.")
 @SpringBootTest
-class PlaceScrapingTest {
+class KakaoPlaceScrapingTest {
 
     @Autowired
     private KakaoPlaceScrapingController sut;
@@ -37,6 +39,7 @@ class PlaceScrapingTest {
 
         // then
         if (openingHours != null) {
+            assertThat(actualResult.getOpeningHours()).isNotNull();
             assertThat(actualResult.getOpeningHours().size()).isEqualTo(openingHours.size());
             for (int i = 0; i < openingHours.size(); i++) {
                 assertThat(actualResult.getOpeningHours().get(i).getDay()).isEqualTo(openingHours.get(i).getDay());
@@ -60,7 +63,7 @@ class PlaceScrapingTest {
                                 OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
                                 OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30))),
                                 OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(10, 30), LocalTime.of(15, 30)))),
-                        "월요일", null),
+                        "월요일", "https://app.catchtable.co.kr/ct/shop/moru"),
                 arguments("308342289",
                         List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
                                 OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),
@@ -71,13 +74,13 @@ class PlaceScrapingTest {
                                 OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0)))),
                         null, "https://www.instagram.com/toma_wv/"),
                 arguments("25001083",
-                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
-                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
-                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
-                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
-                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
-                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59))),
-                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(7, 30), LocalTime.of(23, 59)))),
+                        List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(8, 0), LocalTime.of(0, 0))),
+                                OpeningHourDto.of(TUE, TimeDto.of(LocalTime.of(8, 0), LocalTime.of(0, 0))),
+                                OpeningHourDto.of(WED, TimeDto.of(LocalTime.of(8, 0), LocalTime.of(0, 0))),
+                                OpeningHourDto.of(THU, TimeDto.of(LocalTime.of(8, 0), LocalTime.of(0, 0))),
+                                OpeningHourDto.of(FRI, TimeDto.of(LocalTime.of(8, 0), LocalTime.of(0, 0))),
+                                OpeningHourDto.of(SAT, TimeDto.of(LocalTime.of(8, 0), LocalTime.of(0, 0))),
+                                OpeningHourDto.of(SUN, TimeDto.of(LocalTime.of(8, 0), LocalTime.of(0, 0)))),
                         null, "http://www.mcdonalds.co.kr/"),
                 arguments("24529744",
                         List.of(OpeningHourDto.of(MON, TimeDto.of(LocalTime.of(11, 30), LocalTime.of(22, 0))),

--- a/src/test/java/com/zelusik/scraping/unit/service/KakaoPlaceScrapingServiceTest.java
+++ b/src/test/java/com/zelusik/scraping/unit/service/KakaoPlaceScrapingServiceTest.java
@@ -5,6 +5,7 @@ import com.zelusik.scraping.dto.place.OpeningHourDto;
 import com.zelusik.scraping.dto.place.TimeDto;
 import com.zelusik.scraping.service.KakaoPlaceScrapingService;
 import com.zelusik.scraping.util.OpeningHoursConverter;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,19 +78,15 @@ class KakaoPlaceScrapingServiceTest {
         String closingHours = "월요일\n화요일";
         BusinessHoursDto expectedResult = new BusinessHoursDto(openingHourDtos, closingHours);
 
-        given(mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo " +
-                "div.location_detail.openhour_wrap > div.location_present a.btn_more"))).willReturn(button);
+        given(mArticle.findElement(By.cssSelector("div.cont_essential > div.details_placeinfo div.location_detail.openhour_wrap > div.location_present a.btn_more"))).willReturn(button);
         willDoNothing().given(button).click();
         given(mArticle.findElement(By.cssSelector("div.details_placeinfo div.fold_floor > div.inner_floor"))).willReturn(operationList);
         WebElement openingHoursElem = createWebElemMock("openingHours");
-        given(operationList.findElement(By.cssSelector("ul:nth-child(2)"))).willReturn(openingHoursElem);
+        given(operationList.findElement(By.cssSelector("div.displayPeriodList > ul:nth-child(2)"))).willReturn(openingHoursElem);
         given(openingHoursElem.getText()).willReturn(openingHours);
         WebElement closingHoursTitleElem = createWebElemMock("closingHoursTitle");
-        given(operationList.findElement(By.cssSelector("strong:nth-child(3)"))).willReturn(closingHoursTitleElem);
-        given(closingHoursTitleElem.getText()).willReturn("휴무일");
-        WebElement closingHoursElem = createWebElemMock("closingHours");
-        given(operationList.findElement(By.cssSelector("ul:nth-child(4)"))).willReturn(closingHoursElem);
-        given(closingHoursElem.getText()).willReturn(closingHours);
+        given(operationList.findElement(By.cssSelector("div.displayOffdayList > ul:nth-child(2)"))).willReturn(closingHoursTitleElem);
+        given(closingHoursTitleElem.getText()).willReturn(closingHours);
         given(converter.parseStrToOHs(openingHours)).willReturn(openingHourDtos);
 
         // when
@@ -99,6 +96,11 @@ class KakaoPlaceScrapingServiceTest {
         verifyGetBusinessHours(openingHours, expectedResult, actualResult);
     }
 
+    @Disabled("""
+            23.7.17 기준 "공휴일" 등의 정보가 div.displayPeriodList에 포함되었다.
+            그러므로 현재 코드에서는 "공휴일" 등의 정보를 전혀 추출하지 않고, 그렇기 때문에 바로 위의 test(existsButtonAndOpeningAndClosingHours_whenGetBusinessHours_thenReturnResult)와 로직이 동일하다.
+            어차피 "공휴일" 등의 정보는 현재 필요하지 않지만, 추후 필요할 수도 있으니 단지 test case를 남기기 위해 우선 이 test는 disabled 처리한다.
+            """)
     @DisplayName("영업시간 조회 - 버튼을 눌러 정보 열람 후, 영업시간과 휴무일 모두 있으나 휴무일 이전에 다른 정보(공휴일 등)가 함께 있는 경우")
     @Test
     void existsButtonAndOpeningAndClosingHoursAndAdditionalInfo_whenGetBusinessHours_thenReturnResult() {
@@ -153,9 +155,9 @@ class KakaoPlaceScrapingServiceTest {
         willDoNothing().given(button).click();
         given(mArticle.findElement(By.cssSelector("div.details_placeinfo div.fold_floor > div.inner_floor"))).willReturn(operationList);
         WebElement openingHoursElem = createWebElemMock("openingHours");
-        given(operationList.findElement(By.cssSelector("ul:nth-child(2)"))).willReturn(openingHoursElem);
+        given(operationList.findElement(By.cssSelector("div.displayPeriodList > ul:nth-child(2)"))).willReturn(openingHoursElem);
         given(openingHoursElem.getText()).willReturn(openingHours);
-        given(operationList.findElement(By.cssSelector("strong:nth-child(3)"))).willThrow(NoSuchElementException.class);
+        given(operationList.findElement(By.cssSelector("div.displayOffdayList > ul:nth-child(2)"))).willThrow(NoSuchElementException.class);
         given(converter.parseStrToOHs(openingHours)).willReturn(openingHourDtos);
 
         // when


### PR DESCRIPTION
## 🔥 Related Issue
- Close #12

## 🏃‍ Task
- 변경된 웹페이지(23.7.17)를 기준으로 영업시간과 휴무일을 정상적으로 추출할 수 있도록 리팩토링
- `KakaoPlaceScrapingTest` 통합 테스트에 기재된 test case 중 변경된 정보 반영

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가?
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
